### PR TITLE
Add config option "listen" to allow listening on a specific ip/port

### DIFF
--- a/cmd/doh-translator/main.go
+++ b/cmd/doh-translator/main.go
@@ -91,6 +91,7 @@ func TranslatorStart(c *cli.Context) (err error) {
 	if pxy, err = proxy.New(
 		proxy.WithLogger(logger),
 		proxy.WithResolver(cfg.Resolver()),
+		proxy.WithListen(cfg.Listen()),
 	); err != nil {
 		logger.Error("Unable to create the Proxy instance", zap.Error(err))
 		return err

--- a/config-doh-translator.yaml
+++ b/config-doh-translator.yaml
@@ -1,3 +1,6 @@
+# Address/port to listen on
+listen: ":80"
+
 # IP address and port of the resolver.
 # Note: Comcast public resolver set as default if no resolver 
 # is provided here.

--- a/interfaces.go
+++ b/interfaces.go
@@ -24,6 +24,7 @@ import (
 )
 
 type Config interface {
+	Listen() string
 	Resolver() string
 	Logger() (logger *zap.Logger, err error)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,12 @@ func New(options ...Option) (result translator.Config, err error) {
 	return
 }
 
+// Listen returns the IP/port to listen on
+func (c *cfg) Listen() string {
+	c.viperCfg.SetDefault("listen", ":80")
+	return c.viperCfg.GetString("listen")
+}
+
 // Resolver returns the DNS resolver that is used by the translator
 func (c *cfg) Resolver() string {
 	c.viperCfg.SetDefault("resolver", "75.75.75.75:53")

--- a/pkg/proxy/options.go
+++ b/pkg/proxy/options.go
@@ -38,3 +38,10 @@ func WithResolver(resolver string) Option {
 		p.resolver = resolver
 	}
 }
+
+// WithListen adds an instance of Config to the Proxy instance
+func WithListen(listen string) Option {
+	return func(p *proxy) {
+		p.listen = listen
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -37,6 +37,9 @@ type proxy struct {
 
 	// IP address and port of the resolver.
 	resolver string
+
+	// Address/port to listen on.
+	listen string
 }
 
 // New returns an instance of Translator.
@@ -57,7 +60,7 @@ func (p *proxy) Start(ctx context.Context) (err error) {
 	http.HandleFunc("/", p.serveProxyRequest)
 	p.logger.Info("Starting DOH translator HTTP proxy server")
 	p.logger.Info("Resolver in use:", zap.String("resolver_string", p.resolver))
-	if err := http.ListenAndServe(":80", nil); err != nil {
+	if err := http.ListenAndServe(p.listen, nil); err != nil {
 		panic(err)
 	}
 	return err


### PR DESCRIPTION
A configurable listen address/port allows for more flexibility regarding what environment this can run in over always listening on [::]:80 / 0.0.0.0:80.
